### PR TITLE
feat: add metaclass for incus model classes and incus_model decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,3 +89,11 @@ ignore = [
     # random is not cryptographic
     "S311"
 ]
+
+[tool.pytest.ini_options]
+addopts = "-vvv --cov=src --cov-report html"
+testpaths = [
+    "tests/unit",
+    "tests/integration",
+    "tests/e2e",
+]

--- a/src/pyincus/models/base.py
+++ b/src/pyincus/models/base.py
@@ -1,1 +1,80 @@
 """Base Metaclass and Class for be subclassed by other models."""
+
+from ..config import Unset
+from ..exceptions import PyIncusException
+from .fields import ModelField
+
+
+class BaseIncusMeta(type):
+    """
+    Metaclass for Incus Models.
+
+    Uses ModelField as default for classes and generates __init__ for
+    the models based on the annotations.
+    """
+
+    def __new__(cls, name, bases, attrs):
+        """
+        Instantiate the incus model.
+
+        Uses the ModelField as default value for class for all annotations.
+        """
+        new_class_model_fields = {}
+        methods = []
+        secret_attributes = []
+        for item in attrs.items():
+            attr, value = item
+
+            if callable(value) or isinstance(value, property):
+                methods.append(item)
+            elif attr.startswith('_'):
+                secret_attributes.append(item)
+            else:
+                new_class_model_fields |= (item,)
+
+        model_fields = []
+        for attr in attrs.get('__annotations__', {}):
+            if attr.startswith('_'):
+                continue
+            model_fields.append((attr, ModelField(cls, attr)))
+            new_class_model_fields.setdefault(attr, Unset)
+
+        new_class = type(
+            name, bases, dict((*secret_attributes, *methods, *model_fields))
+        )
+        new_class.__init__ = cls._init
+        if '__post_init__' not in vars(new_class):
+            new_class.__post_init__ = cls._post_init
+        new_class._model_fields = new_class_model_fields
+        return new_class
+
+    def _init(self, **kwargs):
+        """
+        Initialize the incus model.
+
+        Initialize the class with the required fields in the annotations.
+        """
+        kwargs = self._model_fields | kwargs
+        unsets = []
+        for field, value in kwargs.items():
+            if field not in self._model_fields:
+                continue
+            if value is Unset:
+                unsets.append(field)
+            elif not unsets:
+                setattr(self, field, value)
+
+        if unsets:
+            raise PyIncusException(
+                f'The required fields {unsets} are missing.'
+            )
+
+        self.__post_init__(**kwargs)
+
+    def _post_init(self, **kwargs):
+        """Will be called after the initialization."""
+
+
+def incus_model(cls: type):
+    """Apply BaseIncusMeta to class."""
+    return BaseIncusMeta(cls.__name__, tuple(cls.mro()), vars(cls))

--- a/src/pyincus/models/fields.py
+++ b/src/pyincus/models/fields.py
@@ -1,40 +1,63 @@
-"""General Fields for PyIncus Models."""
+"""Model Field and Filter Query classes."""
 
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, Self
 
 from ..config import Unset
 from ..exceptions import PyIncusException
 
 
 class ModelField:
-    """Should be the default class field value of all fields of any model."""
+    """
+    Default value for Models' attributes.
 
-    def __init__(self, cls, field_name: str):
-        """Init model_field class."""
-        self.field_name = field_name
+    All models should have instances of this class as their class default value
+    for their attributes.
+
+    They will return FilterQuery when tested for equality or inequality.
+    They will be instantiated by the BaseIncusMeta.
+    """
+
+    def __init__(self, cls: type, field_name: str) -> None:
+        """
+        Init model_field class.
+
+        :param cls: The model class where this instance is a field.
+        :param field_name: The field name of this instance.
+        """
         self.cls = cls
+        self.field_name = field_name
 
     def __eq__(self, other) -> FilterQuery:  # type: ignore
-        """Return Filter Query for an equality."""
+        """
+        Return Filter Query for an equality.
+
+        :param other: The value to which compare to.
+        :returns: A filter query for equality.
+        """
         return FilterQuery(self, FilterOperation.EQUALS, other)
 
     def __ne__(self, other) -> FilterQuery:  # type: ignore
-        """Return Filter Query for an innequality."""
+        """
+        Return Filter Query for an inequality.
+
+        :param other: The value to which compare to.
+        :returns: A filter query for inequality.
+        """
         return FilterQuery(self, FilterOperation.NOT_EQUALS, other)
 
     def __hash__(self) -> int:
-        """Hash model field."""
+        """Hash the model field for sets."""
         return hash(self.field_name)
 
     def __repr__(self) -> str:
-        """Representation of ModelField."""
+        """Representation of ModelField used for debugging."""
         return f'{self.cls.__name__}.{self.field_name}'
 
     def __str__(self) -> str:
-        """Field name."""
+        """Field name used for queries."""
         return self.field_name
 
 
@@ -48,7 +71,7 @@ class FilterOperation(Enum):
     NOT_EQUALS = 'ne'
 
     def __str__(self) -> str:
-        """Return operation representation."""
+        """Return operation string representation for query."""
         return self.value
 
     @classmethod
@@ -58,7 +81,12 @@ class FilterOperation(Enum):
 
 
 class FilterQuery:
-    """Representation of queries on filter operations."""
+    """
+    Representation of queries for filter operations.
+
+    This class contains the information needed to make a query to incus.
+    By using str(filter_query) the query in incus query format is returned.
+    """
 
     _repr_mapping = {
         FilterOperation.EQUALS: '==',
@@ -69,21 +97,29 @@ class FilterQuery:
 
     def __init__(
         self,
-        first_value,
+        first_value: ModelField | Self,
         operation: FilterOperation,
         second_value: Any = Unset,
-    ):
-        """Init the Filter Query."""
-        if second_value is Unset and operation != FilterOperation.NOT:
+    ) -> None:
+        """
+        Init the Filter Query.
+
+        :param first_value: The value to apply logical operation to.
+        :param operation: The logical operation to apply.
+        :second_value: The value that the operation will be applied in relation
+        to the first one. If the operation is a NOT, this should be Unset.
+        """
+        if (second_value is Unset) ^ (operation == FilterOperation.NOT):
             raise PyIncusException(
                 "Second value must always be set if operation isn't 'not'"
+                " and never be set if operation is 'not'"
             )
         self.first_value = first_value
         self.operation = operation
         self.second_value = second_value
 
     def __repr__(self):
-        """Return a programming-like representation."""
+        """Return a programming-like representation, clear for debugging."""
         if self.second_value is Unset:
             return f'not {self.first_value!r}'
 
@@ -94,7 +130,7 @@ class FilterQuery:
         ))
 
     def __str__(self):
-        """Return the used representation."""
+        """Return a string with the filter following the incus format."""
         if self.second_value is Unset:
             return f'not {self.first_value}'
 
@@ -109,16 +145,16 @@ class FilterQuery:
 
     def __hash__(self):
         """Hashes the query."""
-        return hash(str(self))
+        return hash(self.first_value)
 
     def __and__(self, other) -> FilterQuery:
-        """Return Filter Query for an and."""
+        """Return Filter Query for a conjunction."""
         return FilterQuery(self, FilterOperation.AND, other)
 
     def __or__(self, other) -> FilterQuery:
-        """Return Filter Query for an or."""
+        """Return Filter Query for a disjunction."""
         return FilterQuery(self, FilterOperation.OR, other)
 
     def __invert__(self) -> FilterQuery:
-        """Return Filter Query for a not."""
+        """Return Filter Query for an inversion."""
         return FilterQuery(self, FilterOperation.NOT)

--- a/tests/unit/models/test_base.py
+++ b/tests/unit/models/test_base.py
@@ -1,0 +1,176 @@
+"""Test Base Metaclass and class."""
+
+import asyncio
+
+import pytest
+
+from pyincus.models.base import ModelField, PyIncusException, incus_model
+
+
+@pytest.fixture
+def test_value_int(faker):  # noqa: D103
+    return faker.pyint()
+
+
+@pytest.fixture
+def test_value_string_1(faker):  # noqa: D103
+    return faker.word()
+
+
+@pytest.fixture
+def test_value_string_2(faker):  # noqa: D103
+    return faker.word()
+
+
+@pytest.fixture
+def test_value_string_3(faker):  # noqa: D103
+    return faker.word()
+
+
+@pytest.fixture
+def AttributeTestClass(  # noqa: D103
+    test_value_string_1, test_value_string_2, test_value_string_3
+):
+    @incus_model
+    class TestClass:
+        a: int  # type: ignore
+        b: str = test_value_string_1  # type: ignore
+        _c: int  # type: ignore
+        _d: str = test_value_string_2  # type: ignore
+
+        @property
+        def e(self):
+            return test_value_string_3
+
+    return TestClass
+
+
+def test_incus_model_attributes_default_to_model_field(
+    AttributeTestClass, test_value_int, test_value_string_2
+):
+    """
+    Test if an Incus Model public attributes will be turned into ModelField.
+
+    If the attribute is public, it must be turned into a ModelField.
+    If it is a private or protected attribute, it will not be changed.
+    If it has a default value, it must continue having.
+    If it is a property, it should not be changed.
+    """
+    assert isinstance(AttributeTestClass.a, ModelField)
+    assert isinstance(AttributeTestClass.b, ModelField)
+    assert AttributeTestClass.a.field_name == 'a'
+    assert AttributeTestClass.b.field_name == 'b'
+    assert AttributeTestClass._d == test_value_string_2
+
+
+def test_incus_model_instance_attributes_set_by_constructor(  # noqa: PLR0913, PLR0917
+    faker,
+    AttributeTestClass,
+    test_value_int,
+    test_value_string_1,
+    test_value_string_2,
+    test_value_string_3,
+):
+    """
+    Test if an Incus Model attributes will be set when instantiating.
+
+    Public Attributes should be set on instantiation.
+    Private Attributes should not be set on instantiaion.
+    New attributes will not be set on instantiation.
+    Default values must remain.
+    """
+    test_instance = AttributeTestClass(
+        a=test_value_int,
+        _c=faker.word(),
+        _d=faker.word(),
+        f=faker.pyint(),
+        e=faker.word(),
+    )
+    assert test_instance.a == test_value_int
+    assert test_instance.b == test_value_string_1
+    assert test_instance._d == test_value_string_2
+    assert test_instance.e == test_value_string_3
+    assert not hasattr(test_instance, 'f')
+    assert not hasattr(test_instance, '_c')
+
+
+def test_incus_model_required_attributes_must_be_set(AttributeTestClass):
+    """Test if an exception is raised when requireds attributes are not set."""
+    with pytest.raises(PyIncusException):
+        AttributeTestClass()
+
+
+def test_incus_model_attributes_with_default_values_are_overwritten(
+    AttributeTestClass, test_value_string_3
+):
+    """
+    Test overwriting Incus Model instances attributes with default values.
+
+    Incus Model instances with default attributes will be overwritten if
+    passed in instantiation.
+    """
+    test_instance = AttributeTestClass(
+        a=test_value_string_3, b=test_value_string_3
+    )
+
+    assert test_instance.b == test_value_string_3
+
+
+def test_incus_model_methods_are_set(faker):
+    """Test if an Incus Model has working methods."""
+
+    def test_func_(self):
+        return RETURN_FUNC
+
+    @incus_model
+    class TestClass:
+        def test_func_a(self, a: int) -> int:  # noqa: PLR6301
+            """Synchronous function with annotations."""
+            return a
+
+        test_func = test_func_
+
+        async def test_func_b(self, b):  # noqa: PLR6301
+            """Asynchronous function without annotations."""
+            return b
+
+    test_instance = TestClass()
+    RETURN_FUNC = faker.pyint()
+
+    assert test_instance.test_func_a(RETURN_FUNC) == RETURN_FUNC
+    assert test_instance.test_func() == RETURN_FUNC
+    assert (
+        asyncio.new_event_loop().run_until_complete(
+            test_instance.test_func_b(RETURN_FUNC)
+        )
+        == RETURN_FUNC
+    )
+
+
+def test_post_init(faker):
+    """
+    Test if __post_init__ is called.
+
+    After the auto-generated __init__, the incus model should run the
+    method __post_init__, with signature: __post_init__(self, **kwargs)
+    with kwargs being the attributes passed when instantiating the object.
+    """
+    post_value = faker.pyint()
+    post_salt = faker.pyint()
+    pre_value = faker.pyint()
+
+    @incus_model
+    class TestClass:
+        a: int
+        _b: int
+
+        def __post_init__(self, **kwargs):
+            """Add salt to values."""
+            self.a += post_salt
+            self._b = kwargs.get('_b', 0)
+            self._b += post_salt
+
+    # Assert post init is run always
+    test_instance = TestClass(a=pre_value, _b=post_value)
+    assert test_instance.a == pre_value + post_salt
+    assert test_instance._b == post_value + post_salt

--- a/tests/unit/models/test_general.py
+++ b/tests/unit/models/test_general.py
@@ -4,7 +4,12 @@ import random
 
 import pytest
 
-from pyincus.models.general import FilterOperation, FilterQuery, ModelField
+from pyincus.models.fields import (
+    FilterOperation,
+    FilterQuery,
+    ModelField,
+    PyIncusException,
+)
 
 
 @pytest.fixture
@@ -265,3 +270,22 @@ def test_invert_filter_query_string(random_query):
     result = str(inverted)
 
     assert result == expected
+
+
+@pytest.mark.parametrize(
+    'operation',
+    (
+        FilterOperation.AND,
+        FilterOperation.OR,
+        FilterOperation.NOT,
+        FilterOperation.EQUALS,
+        FilterOperation.NOT_EQUALS,
+    ),
+)
+def test_invalid_filter_query(random_query, operation):
+    """FilterQuery should only be Unset if testing for Not."""
+    with pytest.raises(PyIncusException):
+        if operation == FilterOperation.NOT:
+            FilterQuery(random_query(), operation, random_query())
+        else:
+            FilterQuery(random_query(), operation)


### PR DESCRIPTION
Created Metaclass to be used on Incus Model classes.
Metaclass defaults public class attributes to ModelField instances.
Metaclass auto-generates the __init__.
Metaclass uses __post_init__ that can be overwritten to supply initialization behavior.
Metaclass methods and properties are not changed.

incus_model decorator turns a class into a IncusModel by rebuilding it with BaseIncusMeta.

Closes #14 
